### PR TITLE
Add Assertions

### DIFF
--- a/src/main/java/duke/Task.java
+++ b/src/main/java/duke/Task.java
@@ -185,6 +185,8 @@ public class Task {
             throw new ReadFileException();
         }
 
+        assert details != null && !details.matches("^ *?$");
+
         boolean isDone;
 
         // parse task type


### PR DESCRIPTION
The Task.readTaskFromFile currently assumes that the strings in the
file are not empty or whitespaces.

This assumption may cause errors.

Using assertions will ensure that all the strings are in the valid
formats.